### PR TITLE
Allow FunctionExpression to be async

### DIFF
--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -299,7 +299,7 @@ ClassExpression {
 functionSignature { TypeParamList? ParamList (TypeAnnotation | TypePredicate)? }
 
 FunctionExpression {
-  kw<"function"> Star? VariableDefinition? functionSignature Block
+  async? kw<"function"> Star? VariableDefinition? functionSignature Block
 }
 
 UnaryExpression {


### PR DESCRIPTION
`async` was allowed on FunctionDeclaration and ArrowFunction, but not FunctionExpression. Here’s the fix.