### PR TITLE
Fix parsing of 'null' as type

### DIFF
--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -198,7 +198,7 @@ AmbientDeclaration {
           privacy? (pkwMod<"static"> | tsPkwMod<"abstract">)? pkwMod<"async">? (pkwMod<"get"> | pkwMod<"set"> | Star)?
           (PropertyDefinition | PrivatePropertyDefinition) TypeParamList? ParamList (TypeAnnotation | TypePredicate) semi
         } |
-        PropertyDeclaration |        
+        PropertyDeclaration |
         IndexSignature
       )* "}" }
     } |
@@ -373,6 +373,7 @@ type[@isGroup=Type] {
    String
   } |
   TemplateType |
+  NullType { kw<"null"> } |
   VoidType { kw<"void"> } |
   TypeofType { kw<"typeof"> (VariableName | typeofMemberExpression) } |
   KeyofType { !typePrefix tskw<"keyof"> type } |
@@ -425,7 +426,7 @@ PropertyType {
   PropertyDefinition
   (ArithOp<"+" | "-">? Optional)?
   TypeAnnotation
-}  
+}
 
 ParamTypeList[@name=ParamList] {
   "(" commaSep<"..."? VariableDefinition ~arrow Optional? ~arrow TypeAnnotation?> ")"

--- a/test/typescript.txt
+++ b/test/typescript.txt
@@ -1,3 +1,16 @@
+# Undefined and Null Type {"dialect": "ts"}
+
+let x: undefined
+let y: null
+
+==>
+
+Script(
+  VariableDeclaration(let,VariableDefinition,TypeAnnotation(
+    TypeName)),
+  VariableDeclaration(let,VariableDefinition,TypeAnnotation(
+    NullType(null))))
+
 # Type declaration {"dialect": "ts"}
 
 function foo(a: number, b: "literal" | Map<number, boolean>): RegExp[] {}


### PR DESCRIPTION
FIX: Fix parsing of 'null' as type in TypeScript.