### PR TITLE
Fix missing support for override on properties.

### DIFF
--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -158,6 +158,7 @@ PropertyDeclaration[group=ClassItem] {
   Decorator*
   privacy?
   (pkwMod<"static"> | tsPkwMod<"abstract">)?
+  tsPkwMod<"override">?
   (tsPkwMod<"readonly"> | pkwMod<"accessor">)?
   (propName | PrivatePropertyDefinition)
   (Optional | LogicOp<"!">)?

--- a/test/typescript.txt
+++ b/test/typescript.txt
@@ -215,3 +215,18 @@ let x = 1 satisfies number
 ==>
 
 Script(VariableDeclaration(let,VariableDefinition,Equals,BinaryExpression(Number,satisfies,TypeName)))
+
+# Override modifier on properties {"dialect": "ts"}
+
+class A {
+  override accessor a;
+  static override b = 1;
+  override c = 2;
+}
+
+==>
+
+Script(ClassDeclaration(class,VariableDefinition,ClassBody(
+  PropertyDeclaration(override,accessor,PropertyDefinition),
+  PropertyDeclaration(static,override,PropertyDefinition,Equals,Number),
+  PropertyDeclaration(override,PropertyDefinition,Equals,Number))))


### PR DESCRIPTION
FIX: Typescript allows `override` on all class elements, not just methods.

Downstream issue: [crbug/1399748](https://crbug.com/1399748)