### PR TITLE
Add support for `this` parameter declaration in TypeScript

### DIFF
--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -246,7 +246,7 @@ patternAssignTyped {
 }
 
 ParamList {
-  "(" commaSep<"..." patternAssignTyped | Decorator* privacyArg? tskw<"readonly">? patternAssignTyped> ")"
+  "(" commaSep<"..." patternAssignTyped | Decorator* privacyArg? tskw<"readonly">? patternAssignTyped | kw<"this"> TypeAnnotation> ")"
 }
 
 Block {

--- a/test/typescript.txt
+++ b/test/typescript.txt
@@ -276,3 +276,11 @@ Script(
   ClassDeclaration(class,VariableDefinition,ClassBody(
     MethodDeclaration(declare,PropertyDefinition,ParamList),
     PropertyDeclaration(declare,PropertyDefinition,TypeAnnotation(TypeName)))))
+
+# Declare this in a Function {"dialect": "ts"}
+
+function foo(this: User) {}
+
+==>
+
+Script(FunctionDeclaration(function,VariableDefinition,ParamList(this,TypeAnnotation(TypeName)),Block))


### PR DESCRIPTION
FIX: Properly parse `this: Type` within parameter lists for TypeScript.

Bug: https://crbug.com/1436873

Closes https://github.com/lezer-parser/javascript/issues/19