### PR TITLE
Add types to "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     "import": "./dist/index.es.js",
-    "require": "./dist/index.cjs"
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Resolves https://github.com/lezer-parser/javascript/issues/21

I tested this change here, via patch: https://github.com/NullVoxPopuli/limber/pull/1050/commits/33242070d07eb0169f6ef809f87cd438c64133a5