### PR TITLE
regex's trailing `/` is not optional

### DIFF
--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -680,7 +680,7 @@ intersectionOp[@name=LogicOp] { "&" }
 
   @precedence { "*", ArithOp }
 
-  RegExp[isolate] { "/" (![/\\\n[] | "\\" ![\n] | "[" (![\n\\\]] | "\\" ![\n])* "]")+ ("/" $[dgimsuvy]*)? }
+  RegExp[isolate] { "/" (![/\\\n[] | "\\" ![\n] | "[" (![\n\\\]] | "\\" ![\n])* "]")+ "/" $[dgimsuvy]* }
 
   LessThan[@name=CompareOp] { "<" }
 


### PR DESCRIPTION
Sorry, would've combined this with the other PR if I'd thought harder, but just realized what the grammar was saying.