### PR TITLE
Support new.target

### DIFF
--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -285,6 +285,7 @@ expressionNoComma {
   RegExp |
   ArrayExpression |
   ObjectExpression { "{" commaSep<Property> ~destructure "}" } |
+  NewTarget { kw<"new"> "." PropertyName } |
   NewExpression { kw<"new"> expressionNoComma (!newArgs TypeArgList? ArgList)? } |
   UnaryExpression |
   YieldExpression |

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -383,3 +383,18 @@ foo()
 ==>
 
 Script(Hashbang,ExpressionStatement(CallExpression(VariableName,ArgList)))
+
+# new.target
+
+function MyObj() {
+  if (!new.target) {
+    throw new Error('Must construct MyObj with new');
+  }
+}
+
+==>
+
+Script(
+  FunctionDeclaration(function,VariableDefinition,ParamList,Block(
+    IfStatement(if,ParenthesizedExpression(UnaryExpression(LogicOp,NewTarget(new,PropertyName))), Block(
+      ThrowStatement(throw,NewExpression(new,VariableName,ArgList(String))))))))


### PR DESCRIPTION
Stumbled over this error when parsing a bundle in the DevTools formatter with Lezer.

Copied the rule from `import.meta`, so let me know if this is the right way or if the rule should be written as `NewTarget { kw<"new"> ".target" }` or something else instead.